### PR TITLE
Avoid memory leak:

### DIFF
--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -152,6 +152,11 @@ QJsonModel::QJsonModel(QObject *parent) :
 
 }
 
+QJsonModel::~QJsonModel()
+{
+    delete mRootItem;
+}
+
 bool QJsonModel::load(const QString &fileName)
 {
     QFile file(fileName);
@@ -177,6 +182,7 @@ bool QJsonModel::loadJson(const QByteArray &json)
     if (!mDocument.isNull())
     {
         beginResetModel();
+        delete mRootItem;
         if (mDocument.isArray()) {
             mRootItem = QJsonTreeItem::load(QJsonValue(mDocument.array()));
         } else {

--- a/qjsonmodel.h
+++ b/qjsonmodel.h
@@ -75,6 +75,7 @@ class QJsonModel : public QAbstractItemModel
     Q_OBJECT
 public:
     explicit QJsonModel(QObject *parent = 0);
+    ~QJsonModel();
     bool load(const QString& fileName);
     bool load(QIODevice * device);
     bool loadJson(const QByteArray& json);


### PR DESCRIPTION
 - delete root item on destruction, also when replacing the root
   with newly loaded data.

Reported by Coverity Scan (on the GPL copy included in calamares/calamares).
This fix provided under MIT license without copyright attribution line
by Adriaan de Groot.

Changing the sample main.cpp to load the JSON 4 times, and to delete
model at the end of main, gives Valgrind results like this:

==4658== LEAK SUMMARY:
==4658==    definitely lost: 200 bytes in 5 blocks
==4658==    indirectly lost: 7,448 bytes in 188 blocks
==4658==      possibly lost: 0 bytes in 0 blocks
==4658==    still reachable: 185,483 bytes in 567 blocks

after the change:

==4681== LEAK SUMMARY:
==4681==    definitely lost: 0 bytes in 0 blocks
==4681==    indirectly lost: 0 bytes in 0 blocks
==4681==      possibly lost: 368 bytes in 1 blocks
==4681==    still reachable: 185,483 bytes in 567 blocks