### PR TITLE
Fix: Root TreeItem (Object and  Array) are not editable

### DIFF
--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -312,8 +312,13 @@ int QJsonModel::columnCount(const QModelIndex &parent) const
 
 Qt::ItemFlags QJsonModel::flags(const QModelIndex &index) const
 {
-    int col = index.column();
-    if (col == 1) {
+    int col   = index.column();
+    auto item = static_cast<QJsonTreeItem*>(index.internalPointer());
+
+    auto isArray = QJsonValue::Array == item->type();
+    auto isObject = QJsonValue::Object == item->type();
+
+    if ((col == 1) && !(isArray || isObject)) {
         return Qt::ItemIsEditable | QAbstractItemModel::flags(index);
     } else {
         return QAbstractItemModel::flags(index);


### PR DESCRIPTION
Prevent enter in edit mode when "double click" on root item,
The root item represent objects and arrays