### PR TITLE
Support double type for QJsonTreeItem

### DIFF
--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -76,6 +76,11 @@ void QJsonTreeItem::setValue(const QString &value)
     mValue = value;
 }
 
+void QJsonTreeItem::setValue(const double& value)
+{
+    mDValue = value;
+}
+
 void QJsonTreeItem::setType(const QJsonValue::Type &type)
 {
     mType = type;
@@ -89,6 +94,11 @@ QString QJsonTreeItem::key() const
 QString QJsonTreeItem::value() const
 {
     return mValue;
+}
+
+double QJsonTreeItem::double_value() const
+{
+    return mDValue;
 }
 
 QJsonValue::Type QJsonTreeItem::type() const
@@ -128,9 +138,10 @@ QJsonTreeItem* QJsonTreeItem::load(const QJsonValue& value, QJsonTreeItem* paren
             rootItem->appendChild(child);
             ++index;
         }
-    }
-    else
-    {
+    }else if ( value.isDouble()){
+        rootItem->setValue(value.toDouble());
+        rootItem->setType(value.type());
+    } else {
         rootItem->setValue(value.toVariant().toString());
         rootItem->setType(value.type());
     }
@@ -245,8 +256,6 @@ QVariant QJsonModel::data(const QModelIndex &index, int role) const
             return QString("%1").arg(item->value());
         }
     }
-
-
 
     return QVariant();
 
@@ -385,6 +394,9 @@ QJsonValue  QJsonModel::genJson(QJsonTreeItem * item) const
             arr.append(genJson(ch));
         }
         return arr;
+    } else if (QJsonValue::Double == type) {
+        QJsonValue va(item->double_value());
+        return va;
     } else {
         QJsonValue va(item->value());
         return va;

--- a/qjsonmodel.cpp
+++ b/qjsonmodel.cpp
@@ -249,11 +249,20 @@ QVariant QJsonModel::data(const QModelIndex &index, int role) const
         if (index.column() == 0)
             return QString("%1").arg(item->key());
 
-        if (index.column() == 1)
-            return QString("%1").arg(item->value());
+        if (index.column() == 1) {
+            if (item->type() == QJsonValue::Double) {
+                return QString("%1").arg(item->double_value());
+            } else {
+                return QString("%1").arg(item->value());
+            }
+        }
     } else if (Qt::EditRole == role) {
         if (index.column() == 1) {
-            return QString("%1").arg(item->value());
+            if (item->type() == QJsonValue::Double) {
+                return QString("%1").arg(item->double_value());
+            } else {
+                return QString("%1").arg(item->value());
+            }
         }
     }
 
@@ -267,7 +276,11 @@ bool QJsonModel::setData(const QModelIndex &index, const QVariant &value, int ro
     if (Qt::EditRole == role) {
         if (col == 1) {
             QJsonTreeItem *item = static_cast<QJsonTreeItem*>(index.internalPointer());
+            if (item->type() == QJsonValue::Double) {
+                item->setValue(value.toDouble());
+            } else {
                 item->setValue(value.toString());
+            }
                 emit dataChanged(index, index, {Qt::EditRole});
                 return true;
         }

--- a/qjsonmodel.h
+++ b/qjsonmodel.h
@@ -47,9 +47,11 @@ public:
     int row() const;
     void setKey(const QString& key);
     void setValue(const QString& value);
+    void setValue(const double& value);
     void setType(const QJsonValue::Type& type);
     QString key() const;
     QString value() const;
+    double double_value() const;
     QJsonValue::Type type() const;
 
 
@@ -59,6 +61,7 @@ protected:
 
 
 private:
+    double mDValue;
     QString mKey;
     QString mValue;
     QJsonValue::Type mType;


### PR DESCRIPTION
It would be nice if you could make number keeps in `QJsonModel` as is, not storage by a string with quotes.

The `QJsonTreeItem` treats anything as `QString` before, this made some parser reject the data type generated by` QJsonTreeItem`.

like [nlohmann/json](https://github.com/nlohmann/json) will tell:
```
[json.exception.type_error.302] type must be number, but is string
```