### PR TITLE
[Python] Fix list element sorting in view, add QJsonModel.clear

### DIFF
--- a/qjsonmodel.py
+++ b/qjsonmodel.py
@@ -131,6 +131,9 @@ class QJsonModel(QtCore.QAbstractItemModel):
         self._rootItem = QJsonTreeItem()
         self._headers = ("key", "value")
 
+    def clear(self):
+        self.load({})
+
     def load(self, document):
         """Load from dictionary
 

--- a/qjsonmodel.py
+++ b/qjsonmodel.py
@@ -113,7 +113,7 @@ class QJsonTreeItem(object):
         elif isinstance(value, list):
             for index, value in enumerate(value):
                 child = self.load(value, rootItem)
-                child.key = str(index)
+                child.key = index
                 child.type = type(value)
                 rootItem.appendChild(child)
 


### PR DESCRIPTION
Hi @dridk , this PR fix the list element sorting in Python implementation.

Previously the index has converted into string type, and the sorting result is not desirable, 👇🏼 

![image](https://user-images.githubusercontent.com/3357009/96615428-d69ff880-1333-11eb-96f9-b5373b4701e4.png)

After the change, this should be the expected result, 👇🏼 

![image](https://user-images.githubusercontent.com/3357009/96615326-b40ddf80-1333-11eb-84f3-d663f7c0e9f9.png)


Also, I have added the `clear` method which is being called in the test case, but not actually being implemented.

Thanks :)
