### PR TITLE
Fix CMake to be included via CPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,11 @@ target_include_directories(QJsonModel PUBLIC include)
 
 add_library(QJsonModelStatic STATIC)
 add_library(Qt6::QJsonModelStatic ALIAS QJsonModelStatic)
-set_target_properties(QJsonModelStatic PROPERTIES OUTPUT_NAME "QJsonModel")
+if(WIN32)
+  set_target_properties(QJsonModelStatic PROPERTIES OUTPUT_NAME "QJsonModelLIB")
+else()
+  set_target_properties(QJsonModelStatic PROPERTIES OUTPUT_NAME "QJsonModel")
+endif()
 target_link_libraries(QJsonModelStatic PUBLIC QJsonModel)
 
 add_library(QJsonModelShared SHARED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,48 +1,20 @@
 cmake_minimum_required(VERSION 3.26)
-
-message(WARNING "MODULE_PATH: ${CMAKE_MODULE_PATH}")
-
-# Additional paths to search for custom and third-party CMake modules
-list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMake)
-
-include(BuildProperties)
-
-prevent_in_source_build()
-disable_deprecated_features()
-
-# When this package is included as a subproject, there's no need to
-# build and run the unit-tests.
-disable_tests_if_subproject()
-#git_setup_submodules()
-
 project(Qt6JsonModel
 	VERSION 0.0.2
 	LANGUAGES C CXX
 	# Save this for later:
-	# HOMEPAGE_URL <URL>
 	DESCRIPTION "QJsonModel is a json tree model class for Qt6/C++17 based on QAbstractItemModel. MIT License."
 )
 
-detect_linkers()
-
-include(CPM)
-
-SET(QJsonModel_TOP_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-
-# enable compile_commands.json generation for clangd
-set(CMAKE_EXPORT_COMPILE_COMMANDS On)
-
 IF(NOT CMAKE_BUILD_TYPE)
-	SET( CMAKE_BUILD_TYPE Debug )
+        SET( CMAKE_BUILD_TYPE Debug )
 ENDIF()
 
 set(CMAKE_C_STANDARD 17)
 set(CMAKE_CXX_STANDARD 20)
-
-# Disable GNU compiler extensions
-oset(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_C_EXTENSIONS OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
-
+set(QJsonModel_PUBLIC_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
 
 find_package(Qt6 COMPONENTS
 	Core REQUIRED
@@ -50,71 +22,30 @@ find_package(Qt6 COMPONENTS
 	Gui REQUIRED
 )
 qt_standard_project_setup()
-
-# Set output directories for build targets
-#set_artifact_dir(${CMAKE_BINARY_DIR}/out)
-
-include(CheckIncludeFile)
-
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-	add_compile_definitions(-DDEBUG=1 -DQDEBUG=1)
-endif()
-
-qt_add_library(QJsonModel
-OBJECT
+qt_add_library(QJsonModel OBJECT
 	QJsonModel.cpp
+        include/QJsonModel.hpp
 )
-#set_target_properties(QJsonModel PROPERTIES EXPORT_NAME QJsonModel)
 add_library(Qt6::QJsonModel ALIAS QJsonModel)
-
-# Since headers are in the include/ directory, going to handle MOC invocation
-# manually.
-set_target_properties(QJsonModel PROPERTIES
-	AUTOMOC OFF
-	POSITION_INDEPENDENT_CODE ON
+target_include_directories(QJsonModel PUBLIC
+        ${QJsonModel_PUBLIC_INCLUDE_DIR}
 )
-
-set(QJsonModel_PUBLIC_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
-#file(MAKE_DIRECTORY ${Qt6JsonModel_TOP_SOURCE_DIR})
-
-add_custom_target(QJsonModel_include_files COMMAND ${CMAKE_COMMAND} -E copy_directory ${QJsonModel_TOP_SOURCE_DIR}/include ${QJsonModel_PUBLIC_INCLUDE_DIR}
-    DEPENDS ${QJsonModel_TOP_SOURCE_DIR}/include
-    COMMENT "Copying include files to ${QJsonModel_PUBLIC_INCLUDE_DIR}"
+target_link_libraries(QJsonModel PUBLIC
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
 )
-
-target_include_directories(QJsonModel
-SYSTEM BEFORE
-PUBLIC ${QJsonModel_PUBLIC_INCLUDE_DIR}
-)
-add_dependencies(QJsonModel QJsonModel_include_files)
-
-# Manually call moc on all header files
-file(GLOB_RECURSE QJsonModel_HEADER_FILES
-	${QJsonModel_TOP_SOURCE_DIR}/include/**.hpp)
-
-qt_wrap_cpp(QJsonModel_MOC_SOURCES  ${QJsonModel_HEADER_FILES}
-	TARGET QJsonModel
-)
-
-# Append the MOC files to the source list
-target_sources(QJsonModel PUBLIC ${QJsonModel_MOC_SOURCES})
 
 add_library(QJsonModelStatic STATIC)
 add_library(Qt6::QJsonModelStatic ALIAS QJsonModelStatic )
 set_target_properties(QJsonModelStatic PROPERTIES OUTPUT_NAME "QJsonModel")
+target_link_libraries(QJsonModelStatic PUBLIC QJsonModel)
+target_include_directories(QJsonModelStatic PUBLIC ${QJsonModel_PUBLIC_INCLUDE_DIR})
 
-add_library(QJsonModelShared SHARED )
-add_library(Qt6::QJsonModelShared ALIAS QJsonModelShared )
+add_library(QJsonModelShared SHARED)
+add_library(Qt6::QJsonModelShared ALIAS QJsonModelShared)
 set_target_properties(QJsonModelShared PROPERTIES OUTPUT_NAME "QJsonModel")
-
-target_link_libraries(QJsonModelStatic PRIVATE QJsonModel)
-target_link_libraries(QJsonModelShared PRIVATE QJsonModel)
-
-target_link_libraries(QJsonModel
-PUBLIC
-	Qt6::Core
-	Qt6::Gui
-	Qt6::Widgets
-)
+target_link_libraries(QJsonModelShared PUBLIC QJsonModel)
+target_include_directories(QJsonModelShared PUBLIC ${QJsonModel_PUBLIC_INCLUDE_DIR})
 
 # vim: ts=2 sw=2 noet foldmethod=indent :

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,51 +1,31 @@
 cmake_minimum_required(VERSION 3.26)
-project(Qt6JsonModel
-	VERSION 0.0.2
-	LANGUAGES C CXX
-	# Save this for later:
-	DESCRIPTION "QJsonModel is a json tree model class for Qt6/C++17 based on QAbstractItemModel. MIT License."
+project(
+  Qt6JsonModel
+  VERSION 0.0.2
+  LANGUAGES CXX
+  DESCRIPTION
+    "QJsonModel is a json tree model class for Qt6/C++17 based on QAbstractItemModel. MIT License."
 )
 
-IF(NOT CMAKE_BUILD_TYPE)
-        SET( CMAKE_BUILD_TYPE Debug )
-ENDIF()
-
-set(CMAKE_C_STANDARD 17)
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_C_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(QJsonModel_PUBLIC_INCLUDE_DIR ${CMAKE_BINARY_DIR}/include)
 
-find_package(Qt6 COMPONENTS
-	Core REQUIRED
-	Widgets REQUIRED
-	Gui REQUIRED
-)
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Gui)
 qt_standard_project_setup()
-qt_add_library(QJsonModel OBJECT
-	QJsonModel.cpp
-        include/QJsonModel.hpp
-)
+qt_add_library(QJsonModel OBJECT QJsonModel.cpp include/QJsonModel.hpp)
 add_library(Qt6::QJsonModel ALIAS QJsonModel)
-target_include_directories(QJsonModel PUBLIC
-        ${QJsonModel_PUBLIC_INCLUDE_DIR}
-)
-target_link_libraries(QJsonModel PUBLIC
-        Qt6::Core
-        Qt6::Gui
-        Qt6::Widgets
-)
+target_link_libraries(QJsonModel PUBLIC Qt6::Core Qt6::Gui Qt6::Widgets)
+target_include_directories(QJsonModel PUBLIC include)
 
 add_library(QJsonModelStatic STATIC)
-add_library(Qt6::QJsonModelStatic ALIAS QJsonModelStatic )
+add_library(Qt6::QJsonModelStatic ALIAS QJsonModelStatic)
 set_target_properties(QJsonModelStatic PROPERTIES OUTPUT_NAME "QJsonModel")
 target_link_libraries(QJsonModelStatic PUBLIC QJsonModel)
-target_include_directories(QJsonModelStatic PUBLIC ${QJsonModel_PUBLIC_INCLUDE_DIR})
 
 add_library(QJsonModelShared SHARED)
 add_library(Qt6::QJsonModelShared ALIAS QJsonModelShared)
 set_target_properties(QJsonModelShared PROPERTIES OUTPUT_NAME "QJsonModel")
 target_link_libraries(QJsonModelShared PUBLIC QJsonModel)
-target_include_directories(QJsonModelShared PUBLIC ${QJsonModel_PUBLIC_INCLUDE_DIR})
 
 # vim: ts=2 sw=2 noet foldmethod=indent :


### PR DESCRIPTION
Main problem was that the header was not found by the containing proect. Took also the liberty to cleanup the CMakeLists.txt. I also fixed compilation under MSVC (only build system problems, code compiles perfectly).

Now including the project is as simple as:
```CMake

CPMAddPackage("gh:/dridk/QJsonModel#master")

target_link_libraries(my_epic_app Qt6::Core Qt6::Widgets Qt6::PrintSupport Qt6::Svg Qt6::Xml QJsonModelStatic)
```

Then in your C++ file:

```C++

auto model = new QJsonModel();
model->loadJson(str.toUtf8());
treeView->setModel(model);
```

I might need to review the commit message, as its kinda.. not ideal :) and also squash the commits - if the fixes are good for you.