### PR TITLE
feat: add option to display quotes around string values

### DIFF
--- a/QJsonModel.cpp
+++ b/QJsonModel.cpp
@@ -253,8 +253,13 @@ QVariant QJsonModel::data(const QModelIndex &index, int role) const {
     if (index.column() == 0)
       return QString("%1").arg(item->key());
 
-    if (index.column() == 1)
+    if (index.column() == 1) {
+      if (mQuoteVisible && item->type() == QJsonValue::String) {
+        QString value = item->value().toString();
+        return QString("\"%1\"").arg(value);
+      }
       return item->value();
+    }
   } else if (Qt::EditRole == role) {
     if (index.column() == 1)
       return item->value();
@@ -467,6 +472,14 @@ void QJsonModel::valueToJson(QJsonValue jsonValue, QByteArray &json, int indent,
 
 void QJsonModel::addException(const QStringList &exceptions) {
   mExceptions = exceptions;
+}
+
+void QJsonModel::setQuoteVisible(bool visible) {
+  mQuoteVisible = visible;
+}
+
+bool QJsonModel::quoteVisible() const {
+  return mQuoteVisible;
 }
 
 QJsonValue QJsonModel::genJson(QJsonTreeItem *item) const {

--- a/include/QJsonModel.hpp
+++ b/include/QJsonModel.hpp
@@ -105,10 +105,14 @@ public:
   //! List of tags to skip during JSON parsing
   void addException(const QStringList &exceptions);
 
+  // Display format control
+  void setQuoteVisible(bool visible);
+  bool quoteVisible() const;
 private:
   QJsonValue genJson(QJsonTreeItem *) const;
   QJsonTreeItem *mRootItem = nullptr;
   QStringList mHeaders;
+  bool mQuoteVisible = false;
   //! List of exceptions (e.g. comments). Case insensitive, compairs on
   //! "contains".
   QStringList mExceptions;


### PR DESCRIPTION
@dridk Hi, I've added an option to visually distinguish strings from other types when needed. Please review it.
Thanks for your feedback in advance.


<img width="898" height="639" alt="image" src="https://github.com/user-attachments/assets/bebad510-90f0-439c-913b-a11d289961a5" />
